### PR TITLE
develope 브랜치 merge 규칙 테스트

### DIFF
--- a/SyncCodaAndGithub/python/test/test_coda_api.py
+++ b/SyncCodaAndGithub/python/test/test_coda_api.py
@@ -21,7 +21,7 @@ class TestCodaAPIEndToEnd(unittest.TestCase):
 
     def test_list_pages_with_wrong_app_key(self):
         response = coda_api.listPages(coda_api_key="wrong_app_key", doc_id='OBsatQ1Yn9')
-        self.assertIsNone(response)
+        self.assertFalse(True)
 
 if __name__ == '__main__':
     if len(sys.argv) <= 1:


### PR DESCRIPTION
merge 전에 테스트 실패하면 merge 불가능하게 설정했음. test를 위해 실패한 테스트 코드 작성함